### PR TITLE
Fixes #40: Remove methods where code quality is not important

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -34,6 +34,10 @@
                 <directory>../src/*/*Bundle/Tests</directory>
                 <directory>../src/*/Bundle/*Bundle/Resources</directory>
                 <directory>../src/*/Bundle/*Bundle/Tests</directory>
+                <directory>../src/*/*Bundle/ResponseCode</directory>
+                <directory>../src/*/*Bundle/DependencyInjection</directory>
+                <file>../src/ScrumManager/ApiBundle/ScrumManagerApiBundle.php</file>
+                <file>../src/ScrumManager/ApiBundle/Entity/SerializableInterface.php</file>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
Coveralls CC failed, so trying a new method of organising phpunit.xml.dist

Added another fix for Coveralls due to a typo in previous commit
